### PR TITLE
fix account uid for necessary commands

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Smartling/smartling-cli/services/helpers/rlog"
 
 	sdk "github.com/Smartling/api-sdk-go"
-	api "github.com/Smartling/api-sdk-go/api/mt"
 	"github.com/kovetskiy/lorg"
 )
 
@@ -46,9 +45,6 @@ func Config() (config.Config, error) {
 	}
 	cnf, err := config.BuildConfigFromFlags(params)
 	if err != nil {
-		return config.Config{}, err
-	}
-	if err := api.AccountUID(cnf.AccountID).Validate(); err != nil {
 		return config.Config{}, err
 	}
 	return cnf, nil

--- a/cmd/helpers/build/build.go
+++ b/cmd/helpers/build/build.go
@@ -8,7 +8,7 @@ import (
 // These variables will be set via ldflags at build time.
 var (
 	// CliVersion is version information
-	CliVersion = "3.3"
+	CliVersion = "3.3.1"
 	// CommitID is the git commit hash
 	CommitID = ""
 	// Date is date of binary built


### PR DESCRIPTION
Fix: remove unconditional AccountUID validation from shared Config()
                                                                                                                                                                                               
AccountUID was being validated for every command, breaking files push/pull and other file operations for users without account_id in their config. Only mt and jobs progress commands need it — they already validate it themselves via FallbackAccount.

https://github.com/Smartling/smartling-cli/issues/106